### PR TITLE
default to ssl except for port=50000

### DIFF
--- a/98-ibm-db2.js
+++ b/98-ibm-db2.js
@@ -105,7 +105,7 @@ module.exports = function (RED) {
         Db2config.username +
         ";PWD=" +
         Db2config.password;
-      if (Db2config.port == 50001) {
+      if (Db2config.port != 50000) {
         connString = connString + ";Security=SSL";
       }
     }
@@ -370,7 +370,7 @@ module.exports = function (RED) {
         Db2config.username +
         ";PWD=" +
         Db2config.password;
-      if (Db2config.port == 50001) {
+      if (Db2config.port != 50000) {
         connString = connString + ";Security=SSL";
       }
     }


### PR DESCRIPTION
new db2 on cloud (replacing existing Db2 on Cloud instances by end October 2020) only supports ssl, and assigns ephemeral ports 30000+ 
change default from non-ssl except for 50001, to ssl except except for 50000